### PR TITLE
Add caret for @graphql-codegen packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "@graphql-codegen/core": "^1.4.0",
     "@graphql-codegen/introspection": "^1.4.0",
-    "@graphql-codegen/typescript": "1.4.0",
-    "@graphql-codegen/typescript-operations": "1.4.0",
+    "@graphql-codegen/typescript": "^1.4.0",
+    "@graphql-codegen/typescript-operations": "^1.4.0",
     "@types/graphql": "^14.2.2",
     "fs-extra": "^8.1.0",
     "gatsby-node-helpers": "^0.3.0",


### PR DESCRIPTION
This allow the clients of this library to use the latest versions of the packages instead of being locked to `v1.4.0`.